### PR TITLE
Remove hardcoded entity kill list, suggest Stripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Yes, but not any more than other projects currently and for past years.
 
 **Recommended:**
 * [Cleaner Extension](https://github.com/Accelerator74/Cleaner) (Suppresses console warnings)
+* [Stripper:Source](https://forums.alliedmods.net/showthread.php?t=39439) (Allows you to add/modify/removes entities from maps, recommended filter file included)
 
 ## Issue Rules
 

--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1564,15 +1564,6 @@ char g_szStyleAcronyms[][] =
 	"fs"
 };
 
-char EntityList[][] = 													// Disable entities that often break maps
-{
-	"logic_timer",
-	"team_round_timer",
-	"logic_relay",
-	"player_weapon_strip",
-	"player_weaponstrip",
-};
-
 char RadioCMDS[][] = 													// Disable radio commands
 {
 	"coverme", "takepoint", "holdpos", "regroup", "followme", "takingfire", "go", "fallback", "sticktog",
@@ -1768,14 +1759,6 @@ public void OnMapStart()
 	CreateTimer(180.0, AdvertTimer, INVALID_HANDLE, TIMER_FLAG_NO_MAPCHANGE | TIMER_REPEAT);
 
 	int iEnt;
-	for (int i = 0; i < sizeof(EntityList); i++)
-	{
-		while ((iEnt = FindEntityByClassname(iEnt, EntityList[i])) != -1)
-		{
-			AcceptEntityInput(iEnt, "Disable");
-			AcceptEntityInput(iEnt, "Kill");
-		}
-	}
 
 	// PushFix by Mev, George, & Blacky
 	// https://forums.alliedmods.net/showthread.php?t=267131

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -667,14 +667,6 @@ public void OnPlayerThink(int entity)
 public Action Event_OnRoundStart(Handle event, const char[] name, bool dontBroadcast)
 {
 	int iEnt;
-	for (int i = 0; i < sizeof(EntityList); i++)
-	{
-		while ((iEnt = FindEntityByClassname(iEnt, EntityList[i])) != -1)
-		{
-			AcceptEntityInput(iEnt, "Disable");
-			AcceptEntityInput(iEnt, "Kill");
-		}
-	}
 	
 	db_viewMapSettings();
 

--- a/addons/stripper/global_filters.cfg
+++ b/addons/stripper/global_filters.cfg
@@ -1,0 +1,16 @@
+remove:
+{
+"classname" "logic_timer"
+}
+{
+"classname" "team_round_timer"
+}
+{
+"classname" "logic_relay"
+}
+{
+"classname" "player_weapon_strip"
+}
+{
+"classname" "player_weaponstrip"
+}


### PR DESCRIPTION
PR'ing this because it is a breaking change. 

Since CK's inception, there has been a hardcoded "entity kill list". These entities are:
```
	"logic_timer",
	"team_round_timer",
	"logic_relay",
	"player_weapon_strip",
	"player_weaponstrip",
```

Several of these (the top 3 notably) are present on old ported Jail maps, which would teleport everyone to a jail after X minutes, or after someone has finished the map first. It is good to remove these globally, however there are a few maps that break, or have missing features due to stripping these entities blindly.

With Stripper, you can still remove these entities globally, but you can also re-add necessary entities back through map-specific files if need be. In the timer's current state, you would just be SOL.

With this PR, I removed the entity kill list hardcoded in the plugin, included a global stripper file that kills the same entities, and added Stripper to the recommended section of the Readme. Many people run Stripper already to fix/modify maps, so this wouldn't really be anything new.