### PR TITLE
Fix prespeed exploit

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1338,7 +1338,7 @@ char g_szMapNameFromDatabase[MAXPLAYERS + 1][128];
 // New speed limit variables
 bool g_bInBhop[MAXPLAYERS + 1];
 bool g_bFirstJump[MAXPLAYERS + 1];
-int g_iLastJump[MAXPLAYERS + 1];
+float g_iLastJump[MAXPLAYERS + 1];
 int g_iTicksOnGround[MAXPLAYERS + 1];
 bool g_bNewStage[MAXPLAYERS + 1];
 bool g_bLeftZone[MAXPLAYERS + 1];

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -1336,27 +1336,28 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 			if (!g_bInStartZone[client] && !g_bInStageZone[client])
 				return Plugin_Continue;
 
+			// This logic for detecting bhops is pretty terrible and should be reworked -sneaK
 			g_iTicksOnGround[client] = 0;
-			int time = GetTime();
-			int cTime = time - g_iLastJump[client];
+			float time = GetGameTime();
+			float cTime = time - g_iLastJump[client];
 			if (!g_bInBhop[client])
 			{
 				if (g_bFirstJump[client])
 				{
-					if (cTime > 1)
+					if (cTime > 0.8)
 					{
-						g_bFirstJump[client] = false;
-						g_iLastJump[client] = GetTime();
+						g_bFirstJump[client] = true;
+						g_iLastJump[client] = GetGameTime();
 					}
 					else
 					{
-						g_iLastJump[client] = GetTime();
+						g_iLastJump[client] = GetGameTime();
 						g_bInBhop[client] = true;
 					}
 				}
 				else
 				{
-					g_iLastJump[client] = GetTime();
+					g_iLastJump[client] = GetGameTime();
 					g_bFirstJump[client] = true;
 				}
 			}
@@ -1365,11 +1366,11 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 				if (cTime > 1)
 				{
 					g_bInBhop[client] = false;
-					g_iLastJump[client] = GetTime();
+					g_iLastJump[client] = GetGameTime();
 				}
 				else
 				{
-					g_iLastJump[client] = GetTime();
+					g_iLastJump[client] = GetGameTime();
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #42 

The bhop detection logic is very sub-par and should be re-worked. This should be thoroughly tested, even though I checked to make sure that this patched the exploit.