### PR TITLE
quake sounds fix

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1064,7 +1064,8 @@ public void PlayButtonSound(int client)
 {
 	if (!GetConVarBool(g_hSoundEnabled))
 		return;
-
+	if (!g_bEnableQuakeSounds[client])
+		return;
 	// Players button sound
 	if (!IsFakeClient(client))
 	{


### PR DESCRIPTION
Fixes the bug #3 Stops ALL sounds being played if the user has it turned off in their configs