### PR TITLE
Further optimizations to sql.sp

### DIFF
--- a/addons/sourcemod/scripting/surftimer/db/queries.sp
+++ b/addons/sourcemod/scripting/surftimer/db/queries.sp
@@ -55,8 +55,8 @@ char sql_UpdateLastSeenMySQL[] = "UPDATE ck_playerrank SET lastseen = UNIX_TIMES
 char sql_UpdateLastSeenSQLite[] = "UPDATE ck_playerrank SET lastseen = date('now') where steamid = '%s';";
 char sql_selectTopPlayers[] = "SELECT name, points, finishedmapspro, steamid FROM ck_playerrank WHERE style = %i ORDER BY points DESC LIMIT 100";
 char sql_selectRankedPlayer[] = "SELECT steamid, name, points, finishedmapspro, country, lastseen, timealive, timespec, connections, readchangelog, style from ck_playerrank where steamid='%s';";
-char sql_selectRankedPlayersRank[] = "SELECT name FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i) ORDER BY points;";
 char sql_selectRankedPlayers[] = "SELECT steamid, name from ck_playerrank where points > 0 AND style = 0 ORDER BY points DESC LIMIT 0, 1067;";
+char sql_selectRankedPlayersRank[] = "SELECT COUNT(*) FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i);";
 char sql_CountRankedPlayers[] = "SELECT COUNT(steamid) FROM ck_playerrank WHERE style = %i;";
 char sql_CountRankedPlayers2[] = "SELECT COUNT(steamid) FROM ck_playerrank where points > 0 AND style = %i;";
 char sql_selectPlayerProfile[] = "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, wrcppoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, `groups`, lastseen FROM ck_playerrank WHERE steamid = '%s' AND style = '%i';";
@@ -81,6 +81,7 @@ char sql_selectTopSurfers[] = "SELECT db2.steamid, db1.name, db2.runtimepro as o
 char sql_selectPlayerProCount[] = "SELECT style, count(1) FROM ck_playertimes WHERE mapname = '%s' GROUP BY style;";
 char sql_selectPlayerRankProTime[] = "SELECT COUNT(*) FROM ck_playertimes WHERE runtimepro <= (SELECT runtimepro FROM ck_playertimes WHERE steamid = '%s' AND mapname = '%s' AND style = 0 AND runtimepro > -1.0) AND mapname = '%s' AND style = 0 AND runtimepro > -1.0;";
 char sql_selectAllMapTimesinMap[] = "SELECT runtimepro from ck_playertimes WHERE mapname = '%s';";
+char sql_selectAVGruntimepro[] = "SELECT AVG(runtimepro) FROM ck_playertimes WHERE mapname = '%s';";
 
 // ck_spawnlocations
 char sql_createSpawnLocations[] = "CREATE TABLE IF NOT EXISTS ck_spawnlocations (mapname VARCHAR(54) NOT NULL, pos_x FLOAT NOT NULL, pos_y FLOAT NOT NULL, pos_z FLOAT NOT NULL, ang_x FLOAT NOT NULL, ang_y FLOAT NOT NULL, ang_z FLOAT NOT NULL,  `vel_x` float NOT NULL DEFAULT '0', `vel_y` float NOT NULL DEFAULT '0', `vel_z` float NOT NULL DEFAULT '0', zonegroup INT(12) DEFAULT 0, stage INT(12) DEFAULT 0, teleside INT(11) DEFAULT 0, PRIMARY KEY(mapname, zonegroup, stage, teleside)) DEFAULT CHARSET=utf8mb4;";

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -1450,6 +1450,7 @@ public void db_viewPlayerPointsCallback(Handle owner, Handle hndl, const char[] 
 	if (SQL_HasResultSet(hndl))
 	{
 		int style;
+        
 		while (SQL_FetchRow(hndl))
 		{
 			style = SQL_FetchInt(hndl, 10);
@@ -1463,7 +1464,7 @@ public void db_viewPlayerPointsCallback(Handle owner, Handle hndl, const char[] 
 				g_iTotalConnections[client] = SQL_FetchInt(hndl, 8);
 			}
 		}
-
+        
 		g_iTotalConnections[client]++;
 
 		char updateConnections[1024];
@@ -1529,7 +1530,7 @@ public void db_GetPlayerRank(int client, int style)
 	WritePackCell(pack, style);
 
 	char szQuery[512];
-	// "SELECT name FROM ck_playerrank WHERE points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s') ORDER BY points";
+	// "SELECT COUNT(*) FROM ck_playerrank WHERE points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s') ORDER BY points";
 	Format(szQuery, 512, sql_selectRankedPlayersRank, style, g_szSteamID[client], style);
 	SQL_TQuery(g_hDb, sql_selectRankedPlayersRankCallback, szQuery, pack, DBPrio_Low);
 }
@@ -1555,7 +1556,7 @@ public void sql_selectRankedPlayersRankCallback(Handle owner, Handle hndl, const
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-		g_PlayerRank[client][style] = SQL_GetRowCount(hndl);
+		g_PlayerRank[client][style] = SQL_FetchInt(hndl,0);
 		if (GetConVarInt(g_hPrestigeRank) > 0)
 		{
 			if (GetConVarBool(g_hPrestigeStyles) && !g_bPrestigeAvoid[client])
@@ -1618,12 +1619,13 @@ public void db_viewPlayerProfile(int client, int style, char szSteamId[32], bool
 
 	if (bPlayerFound)
 	{
-		// "SELECT name FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i) ORDER BY points";
+		// "SELECT COUNT(*) FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i);";
 		Format(szQuery, 512, sql_selectRankedPlayersRank, style, szSteamId, style);
 		SQL_TQuery(g_hDb, sql_selectPlayerRankCallback, szQuery, pack, DBPrio_Low);
 	}
 	else
 	{
+        LogError("[SurfTimer] Unknown Player Profile");
 		// "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, groups, lastseen FROM ck_playerrank WHERE name LIKE '%c%s%c' AND style = '%i';"; sql_selectUnknownProfile
 		Format(szQuery, sizeof(szQuery), "SELECT steamid FROM ck_playerrank WHERE style = %i AND name LIKE '%c%s%c' LIMIT 1;", style, PERCENT, szName, PERCENT);
 		SQL_TQuery(g_hDb, sql_selectUnknownPlayerCallback, szQuery, pack, DBPrio_Low);
@@ -1657,7 +1659,7 @@ public void sql_selectUnknownPlayerCallback (Handle owner, Handle hndl, const ch
 		WritePackString(pack, szSteamId);
 		WritePackString(pack, szName);
 
-		// "SELECT name FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i) ORDER BY points";
+		// "SELECT COUNT(*) FROM ck_playerrank WHERE style = %i AND points >= (SELECT points FROM ck_playerrank WHERE steamid = '%s' AND style = %i) ORDER BY points";
 		char szQuery[512];
 		Format(szQuery, 512, sql_selectRankedPlayersRank, style, szSteamId, style);
 		SQL_TQuery(g_hDb, sql_selectPlayerRankCallback, szQuery, pack, DBPrio_Low);
@@ -1687,9 +1689,9 @@ public void sql_selectPlayerRankCallback (Handle owner, Handle hndl, const char[
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-		WritePackCell(pack, SQL_GetRowCount(hndl));
-
-		// "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, wrcppoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, groups, lastseen FROM ck_playerrank WHERE steamid = '%s' AND style = '%i';";
+        WritePackCell(pack, SQL_FetchInt(hndl,0));
+        
+        // "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, wrcppoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, groups, lastseen FROM ck_playerrank WHERE steamid = '%s' AND style = '%i';";
 		char szQuery[512];
 		Format(szQuery, sizeof(szQuery), sql_selectPlayerProfile, szSteamId, style);
 		SQL_TQuery(g_hDb, sql_selectPlayerProfileCallback, szQuery, pack, DBPrio_Low);
@@ -2412,7 +2414,7 @@ public void sql_selectRecordCallback(Handle owner, Handle hndl, const char[] err
 		}
 	}
 	else
-	{ // No record found from database - Let's insert
+	{ // No record found from database - Lets insert
 
 		// Escape name for SQL injection protection
 		char szName[MAX_NAME_LENGTH * 2 + 1], szUName[MAX_NAME_LENGTH];
@@ -2623,7 +2625,7 @@ public void SQL_ViewAllRecordsCallback(Handle owner, Handle hndl, const char[] e
 			PrintToConsole(data, "-------------");
 			PrintToConsole(data, " ");
 		}
-		PrintToConsole(data, "Times on maps which are not in the mapcycle.txt (Records still count but you don't get points): %s", szUncMaps);
+		PrintToConsole(data, "Times on maps which are not in the mapcycle.txt (Records still count but you dont get points): %s", szUncMaps);
 	}
 	if (!bHeader && StrEqual(szUncMaps, ""))
 	{
@@ -2647,7 +2649,8 @@ public void SQL_ViewAllRecordsCallback2(Handle owner, Handle hndl, const char[] 
 		char szSteamId[32];
 		char szMapName[128];
 
-		int rank = SQL_GetRowCount(hndl);
+        int rank = SQL_FetchInt(hndl,0);
+
 		WritePackCell(data, rank);
 		ResetPack(data);
 		ReadPackString(data, szName, MAX_NAME_LENGTH);
@@ -2858,7 +2861,7 @@ public void SQL_ViewTop10RecordsCallback(Handle owner, Handle hndl, const char[]
 			PrintToConsole(data, "-------------");
 			PrintToConsole(data, " ");
 		}
-		PrintToConsole(data, "Times on maps which are not in the mapcycle.txt (Records still count but you don't get points): %s", szUncMaps);
+		PrintToConsole(data, "Times on maps which are not in the mapcycle.txt (Records still count but you dont get points): %s", szUncMaps);
 	}
 	if (!bHeader && StrEqual(szUncMaps, ""))
 	{
@@ -2882,7 +2885,8 @@ public void SQL_ViewTop10RecordsCallback2(Handle owner, Handle hndl, const char[
 		char szSteamId[32];
 		char szMapName[128];
 
-		int rank = SQL_GetRowCount(hndl);
+        int rank = SQL_FetchInt(hndl,0);
+
 		WritePackCell(data, rank);
 		ResetPack(data);
 		ReadPackString(data, szName, MAX_NAME_LENGTH);
@@ -4836,7 +4840,7 @@ public void db_InsertLatestRecords(char szSteamID[32], char szName[128], float F
 public void db_CalcAvgRunTime()
 {
 	char szQuery[256];
-	Format(szQuery, 256, sql_selectAllMapTimesinMap, g_szMapName);
+	Format(szQuery, 256, sql_selectAVGruntimepro, g_szMapName);
 	SQL_TQuery(g_hDb, SQL_db_CalcAvgRunTimeCallback, szQuery, DBPrio_Low);
 }
 
@@ -4854,27 +4858,11 @@ public void SQL_db_CalcAvgRunTimeCallback(Handle owner, Handle hndl, const char[
 		return;
 	}
 
-	g_favg_maptime = 0.0;
-	if (SQL_HasResultSet(hndl))
-	{
-		int rowcount = SQL_GetRowCount(hndl);
-		int i, protimes;
-		float ProTime;
-		while (SQL_FetchRow(hndl))
-		{
-			float pro = SQL_FetchFloat(hndl, 0);
-			if (pro > 0.0)
-			{
-				ProTime += pro;
-				protimes++;
-			}
-			i++;
-			if (rowcount == i)
-			{
-				g_favg_maptime = ProTime / protimes;
-			}
-		}
-	}
+    if (SQL_HasResultSet(hndl)){
+        while (SQL_FetchRow(hndl)){
+            g_favg_maptime = SQL_FetchFloat(hndl,0);
+        }
+    }
 
 	if (g_bhasBonus)
 		db_CalcAvgRunTimeBonus();
@@ -5901,7 +5889,7 @@ public void sql_selectWrcpRecordCallback(Handle owner, Handle hndl, const char[]
 		}
 	}
 	else
-	{ // No record found from database - Let's insert
+	{ // No record found from database - Lets insert
 
 		// Escape name for SQL injection protection
 		char szName2[MAX_NAME_LENGTH * 2 + 1], szUName[MAX_NAME_LENGTH];
@@ -6888,7 +6876,8 @@ public void db_viewStyleMapRankCount(int style)
 {
 	g_StyleMapTimesCount[style] = 0;
 	char szQuery[512];
-	Format(szQuery, 512, "SELECT name FROM ck_playertimes WHERE mapname = '%s' AND style = %i AND runtimepro  > -1.0;", g_szMapName, style);
+	Format(szQuery, 512, "SELECT COUNT(*) FROM ck_playertimes WHERE mapname = '%s' AND style = %i AND runtimepro  > -1.0;", g_szMapName, style);
+
 	SQL_TQuery(g_hDb, sql_selectStylePlayerCountCallback, szQuery, style, DBPrio_Low);
 }
 
@@ -6900,10 +6889,12 @@ public void sql_selectStylePlayerCountCallback(Handle owner, Handle hndl, const 
 		return;
 	}
 
-	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
-	g_StyleMapTimesCount[style] = SQL_GetRowCount(hndl);
-	else
-	g_StyleMapTimesCount[style] = 0;
+	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl)){
+        g_StyleMapTimesCount[style] = SQL_FetchInt(hndl,0);
+    }
+	else {
+	    g_StyleMapTimesCount[style] = 0;
+    }
 
 	return;
 }
@@ -7496,7 +7487,7 @@ public void db_SelectTotalMapCompletesCallback(Handle owner, Handle hndl, const 
 
 		char szQuery[1024];
 
-		Format(szQuery, 1024, "SELECT name,mapname FROM ck_playertimes WHERE runtimepro <= (SELECT runtimepro FROM ck_playertimes WHERE steamid = '%s' AND mapname = '%s' AND runtimepro > -1.0 AND style = 0) AND mapname = '%s' AND style = 0 AND runtimepro > -1.0 ORDER BY runtimepro;", szSteamId, mapname, mapname);
+		Format(szQuery, 1024, "SELECT COUNT(name),mapname FROM ck_playertimes WHERE runtimepro <= (SELECT runtimepro FROM ck_playertimes WHERE steamid = '%s' AND mapname = '%s' AND runtimepro > -1.0 AND style = 0) AND mapname = '%s' AND style = 0 AND runtimepro > -1.0;", szSteamId, mapname, mapname);
 		SQL_TQuery(g_hDb, db_SelectPlayersMapRankCallback, szQuery, pack, DBPrio_Low);
 	}
 	else
@@ -7525,7 +7516,8 @@ public void db_SelectPlayersMapRankCallback(Handle owner, Handle hndl, const cha
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
 		int rank;
-		rank = SQL_GetRowCount(hndl);
+        
+        rank = SQL_FetchInt(hndl,0);
 
 		if (StrEqual(mapname, g_szMapName))
 		{
@@ -7944,7 +7936,9 @@ public void db_getPlayerRankUnknownCallback(Handle owner, Handle hndl, const cha
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-		int playerrank = SQL_GetRowCount(hndl);
+
+		int playerrank = SQL_FetchInt(hndl,0);
+
 
 		CPrintToChatAll("%t", "SQL39", g_szChatPrefix, szName, playerrank, g_pr_RankedPlayers, points);
 	}
@@ -9078,7 +9072,7 @@ public void db_viewCustomTitles(int client, char[] szSteamID)
 	Handle pack = CreateDataPack();
 	WritePackCell(pack, client);
 	WritePackString(pack, szSteamID);
-	Format(szQuery, 728, "SELECT `title`, `namecolour`, `textcolour`, `inuse`, `vip`, `zoner`, `joinmsg` FROM `ck_vipadmins` WHERE `steamid` = '%s'", szSteamID);
+	Format(szQuery, 728, "SELECT `title`, `namecolour`, `textcolour`, `inuse`, `vip`, `zoner`, `joinmsg` FROM `ck_vipadmins` WHERE `steamid` = '%s';", szSteamID);
 	SQL_TQuery(g_hDb, SQL_viewCustomTitlesCallback, szQuery, pack, DBPrio_Low);
 }
 

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -1625,7 +1625,6 @@ public void db_viewPlayerProfile(int client, int style, char szSteamId[32], bool
 	}
 	else
 	{
-        LogError("[SurfTimer] Unknown Player Profile");
 		// "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, groups, lastseen FROM ck_playerrank WHERE name LIKE '%c%s%c' AND style = '%i';"; sql_selectUnknownProfile
 		Format(szQuery, sizeof(szQuery), "SELECT steamid FROM ck_playerrank WHERE style = %i AND name LIKE '%c%s%c' LIMIT 1;", style, PERCENT, szName, PERCENT);
 		SQL_TQuery(g_hDb, sql_selectUnknownPlayerCallback, szQuery, pack, DBPrio_Low);
@@ -1690,11 +1689,11 @@ public void sql_selectPlayerRankCallback (Handle owner, Handle hndl, const char[
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
         WritePackCell(pack, SQL_FetchInt(hndl,0));
-        
+ 
         // "SELECT steamid, steamid64, name, country, points, wrpoints, wrbpoints, wrcppoints, top10points, groupspoints, mappoints, bonuspoints, finishedmapspro, finishedbonuses, finishedstages, wrs, wrbs, wrcps, top10s, groups, lastseen FROM ck_playerrank WHERE steamid = '%s' AND style = '%i';";
-		char szQuery[512];
-		Format(szQuery, sizeof(szQuery), sql_selectPlayerProfile, szSteamId, style);
-		SQL_TQuery(g_hDb, sql_selectPlayerProfileCallback, szQuery, pack, DBPrio_Low);
+        char szQuery[512];
+        Format(szQuery, sizeof(szQuery), sql_selectPlayerProfile, szSteamId, style);
+        SQL_TQuery(g_hDb, sql_selectPlayerProfileCallback, szQuery, pack, DBPrio_Low);
 	}
 	else
 	{
@@ -2644,21 +2643,21 @@ public void SQL_ViewAllRecordsCallback2(Handle owner, Handle hndl, const char[] 
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-		char szQuery[512];
-		char szName[MAX_NAME_LENGTH];
-		char szSteamId[32];
-		char szMapName[128];
+        char szQuery[512];
+        char szName[MAX_NAME_LENGTH];
+        char szSteamId[32];
+        char szMapName[128];
 
         int rank = SQL_FetchInt(hndl,0);
 
-		WritePackCell(data, rank);
-		ResetPack(data);
-		ReadPackString(data, szName, MAX_NAME_LENGTH);
-		ReadPackString(data, szSteamId, 32);
-		ReadPackString(data, szMapName, 128);
+        WritePackCell(data, rank);
+        ResetPack(data);
+        ReadPackString(data, szName, MAX_NAME_LENGTH);
+        ReadPackString(data, szSteamId, 32);
+        ReadPackString(data, szMapName, 128);
 
-		Format(szQuery, 512, sql_selectPlayerProCount, szMapName);
-		SQL_TQuery(g_hDb, SQL_ViewAllRecordsCallback3, szQuery, data, DBPrio_Low);
+        Format(szQuery, 512, sql_selectPlayerProCount, szMapName);
+        SQL_TQuery(g_hDb, SQL_ViewAllRecordsCallback3, szQuery, data, DBPrio_Low);
 	}
 }
 
@@ -2880,21 +2879,21 @@ public void SQL_ViewTop10RecordsCallback2(Handle owner, Handle hndl, const char[
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-		char szQuery[512];
-		char szName[MAX_NAME_LENGTH];
-		char szSteamId[32];
-		char szMapName[128];
+        char szQuery[512];
+        char szName[MAX_NAME_LENGTH];
+        char szSteamId[32];
+        char szMapName[128];
 
         int rank = SQL_FetchInt(hndl,0);
 
-		WritePackCell(data, rank);
-		ResetPack(data);
-		ReadPackString(data, szName, MAX_NAME_LENGTH);
-		ReadPackString(data, szSteamId, 32);
-		ReadPackString(data, szMapName, 128);
+        WritePackCell(data, rank);
+        ResetPack(data);
+        ReadPackString(data, szName, MAX_NAME_LENGTH);
+        ReadPackString(data, szSteamId, 32);
+        ReadPackString(data, szMapName, 128);
 
-		Format(szQuery, 512, sql_selectPlayerProCount, szMapName);
-		SQL_TQuery(g_hDb, SQL_ViewTop10RecordsCallback3, szQuery, data, DBPrio_Low);
+        Format(szQuery, 512, sql_selectPlayerProCount, szMapName);
+        SQL_TQuery(g_hDb, SQL_ViewTop10RecordsCallback3, szQuery, data, DBPrio_Low);
 	}
 }
 
@@ -4846,16 +4845,18 @@ public void db_CalcAvgRunTime()
 
 public void SQL_db_CalcAvgRunTimeCallback(Handle owner, Handle hndl, const char[] error, any data)
 {
-	if (hndl == null)
-	{
-		LogError("[SurfTimer] SQL Error (SQL_db_CalcAvgRunTimeCallback): %s", error);
+    if (hndl == null)
+    {
+        LogError("[SurfTimer] SQL Error (SQL_db_CalcAvgRunTimeCallback): %s", error);
 
-		if (!g_bServerDataLoaded && g_bhasBonus)
-			db_CalcAvgRunTimeBonus();
-		else if (!g_bServerDataLoaded)
-			db_CalculatePlayerCount(0);
+        if (!g_bServerDataLoaded && g_bhasBonus){
+            db_CalcAvgRunTimeBonus();
+        }
+        else if (!g_bServerDataLoaded){
+            db_CalculatePlayerCount(0);
+        }
 
-		return;
+        return;
 	}
 
     if (SQL_HasResultSet(hndl)){
@@ -4864,7 +4865,7 @@ public void SQL_db_CalcAvgRunTimeCallback(Handle owner, Handle hndl, const char[
         }
     }
 
-	if (g_bhasBonus)
+    if (g_bhasBonus)
 		db_CalcAvgRunTimeBonus();
 	else
 		db_CalculatePlayerCount(0);
@@ -7498,28 +7499,28 @@ public void db_SelectTotalMapCompletesCallback(Handle owner, Handle hndl, const 
 
 public void db_SelectPlayersMapRankCallback(Handle owner, Handle hndl, const char[] error, any pack)
 {
-	if (hndl == null)
-	{
-		LogError("[SurfTimer] SQL Error (db_SelectPlayersMapRankCallback): %s ", error);
-	}
+    if (hndl == null)
+    {
+        LogError("[SurfTimer] SQL Error (db_SelectPlayersMapRankCallback): %s ", error);
+    }
 
-	ResetPack(pack);
-	int client = ReadPackCell(pack);
-	char szSteamId[32];
-	char playername[MAX_NAME_LENGTH];
-	char mapname[128];
-	ReadPackString(pack, szSteamId, 32);
-	ReadPackString(pack, playername, sizeof(playername));
-	ReadPackString(pack, mapname, sizeof(mapname));
-	CloseHandle(pack);
+    ResetPack(pack);
+    int client = ReadPackCell(pack);
+    char szSteamId[32];
+    char playername[MAX_NAME_LENGTH];
+    char mapname[128];
+    ReadPackString(pack, szSteamId, 32);
+    ReadPackString(pack, playername, sizeof(playername));
+    ReadPackString(pack, mapname, sizeof(mapname));
+    CloseHandle(pack);
 
-	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
-	{
-		int rank;
-        
+    if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
+    {
+        int rank;
+
         rank = SQL_FetchInt(hndl,0);
 
-		if (StrEqual(mapname, g_szMapName))
+        if (StrEqual(mapname, g_szMapName))
 		{
 			char szGroup[128];
 			if (rank >= 11 && rank <= g_G1Top)
@@ -7936,14 +7937,13 @@ public void db_getPlayerRankUnknownCallback(Handle owner, Handle hndl, const cha
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
-
 		int playerrank = SQL_FetchInt(hndl,0);
-
 
 		CPrintToChatAll("%t", "SQL39", g_szChatPrefix, szName, playerrank, g_pr_RankedPlayers, points);
 	}
-	else
+	else{
 		CPrintToChat(client, "%t", "SQL40", g_szChatPrefix, szName);
+    }
 }
 
 public void db_selectMapImprovement(int client, char szMapName[128])


### PR DESCRIPTION
After reading [ashakiri's](https://github.com/olokos/Surftimer-olokos/commit/6de0d5bab72a898e7bf5a11362e1f4f4bd8c482c) post detailing the poor performance of using the GetRowCount() function I have gone through and replaced it with faster FetchInt() and FetchFloat() functions, along with modifying the original queries to support the use of FetchInt() and FetchFloat().

I have also heavily modified the SQL_db_CalcAvgRunTimeCallback() function which, for some reason, was loading the entire runtimepro column (12000+ entries on one of my servers alone) to derive the average from the column using a while loop. I've replaced this with a new query in queries.sp that simply returns the average from the column and have modified sql.sp to work with this value, if there was some method to the while loop madness I couldn't see it.

The rest of the changes in the 2nd commit are just indentation changes to remove all the compiler warnings.  I have had his build live on 3 of my servers for ~24 hours, with no apparent problems yet.  