### PR TITLE
Replace ColorVariables with ColorLib

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,8 +1,6 @@
 name: Compile with SourceMod
 
-on:
-  push:
-    branches: ["master", "githubActions", "dev"]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -18,6 +16,8 @@ jobs:
 
       - name: Set environment variables
         run: |
+          TOOLS_PATH=$GITHUB_WORKSPACE/tools
+          echo ::set-env name=TOOLS_PATH::$TOOLS_PATH
           SOURCEMOD_PATH=$GITHUB_WORKSPACE/addons/sourcemod
           echo ::set-env name=SOURCEMOD_PATH::$SOURCEMOD_PATH
           echo ::set-env name=SCRIPTS_PATH::$SOURCEMOD_PATH/scripting
@@ -34,16 +34,21 @@ jobs:
       - name: Fetch plugin dependencies
         run: |
           wget https://raw.githubusercontent.com/bcserv/smlib/transitional_syntax/scripting/include/smlib.inc -P $INCLUDE_PATH
-          wget https://raw.githubusercontent.com/PremyslTalich/ColorVariables/master/addons/sourcemod/scripting/includes/colorvariables.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/JoinedSenses/SourceMod-IncludeLibrary/master/include/smjansson.inc -P $INCLUDE_PATH
           wget https://bitbucket.org/Drifter321/dhooks2/raw/009f11c6c518227c51d708af69f4c759147f704b/sourcemod/scripting/include/dhooks.inc -P $INCLUDE_PATH
+          wget https://raw.githubusercontent.com/c0rp3n/colorlib-sm/master/addons/sourcemod/scripting/include/colorlib.inc -P $INCLUDE_PATH
           
           git clone -b transitional_syntax https://github.com/bcserv/smlib.git
           mv smlib/scripting/include/* $INCLUDE_PATH
 
           git clone https://github.com/Deathknife/sourcemod-discord.git
           mv sourcemod-discord/include/* $INCLUDE_PATH
+      
+      - name: Generate colorlib_map.inc
+        run: |
+          wget https://raw.githubusercontent.com/c0rp3n/colorlib-sm/master/tools/color_gen.py -P $TOOLS_PATH
+          python3 $TOOLS_PATH/color_gen.py --include-ref-colors --config "$TOOLS_PATH/colors.yaml" "$INCLUDE_PATH/colorlib_map.inc"
 
       - name: Compile plugin
         run: |

--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -17,7 +17,7 @@
 #include <smlib>
 #include <geoip>
 #include <basecomm>
-#include <colorvariables>
+#include <colorlib>
 #undef REQUIRE_EXTENSIONS
 #include <clientprefs>
 #undef REQUIRE_PLUGIN

--- a/addons/sourcemod/scripting/include/colorlib_map.inc
+++ b/addons/sourcemod/scripting/include/colorlib_map.inc
@@ -1,0 +1,208 @@
+//
+// This file was generated with color_gen.py and should not be used outside of colorlib.inc
+//
+// Do not edit! Regenerate this file with color_gen.py
+//
+
+#if defined _colorlib_map_included
+    #endinput
+#endif
+#define _colorlib_map_included
+
+enum CL_Colors
+{
+    CL_Color_Default = 0x01,
+    CL_Color_Prefix = 0x04,
+    CL_Color_Reply2cmd = 0x01,
+    CL_Color_Showactivity = 0x01,
+    CL_Color_Error = 0x07,
+    CL_Color_Highlight = 0x10,
+    CL_Color_Player = 0x09,
+    CL_Color_Settings = 0x02,
+    CL_Color_Command = 0x02,
+    CL_Color_Team_0 = 0x08,
+    CL_Color_Team_1 = 0x09,
+    CL_Color_Team_2 = 0x11,
+    CL_Color_Teamcolor = 0x03,
+    CL_Color_Red = 0x07,
+    CL_Color_Lightred = 0x0F,
+    CL_Color_Darkred = 0x02,
+    CL_Color_Bluegrey = 0x0A,
+    CL_Color_Blue = 0x0B,
+    CL_Color_Darkblue = 0x0C,
+    CL_Color_Purple = 0x03,
+    CL_Color_Orchid = 0x0E,
+    CL_Color_Orange = 0x10,
+    CL_Color_Yellow = 0x09,
+    CL_Color_Gold = 0x10,
+    CL_Color_Lightgreen = 0x05,
+    CL_Color_Green = 0x04,
+    CL_Color_Lime = 0x06,
+    CL_Color_Grey = 0x08,
+    CL_Color_Grey2 = 0x0D,
+};
+
+CL_Colors _CL_ColorMap(char color[16])
+{
+    if (color[0] == 'd')
+    {
+        if (color[1] == 'e')
+        {
+            return CL_Color_Default;
+        }
+        else if (color[1] == 'a')
+        {
+            if (color[4] == 'r')
+            {
+                return CL_Color_Darkred;
+            }
+            else if (color[4] == 'b')
+            {
+                return CL_Color_Darkblue;
+            }
+        }
+    }
+    else if (color[0] == 'p')
+    {
+        if (color[1] == 'r')
+        {
+            return CL_Color_Prefix;
+        }
+        else if (color[1] == 'l')
+        {
+            return CL_Color_Player;
+        }
+        else if (color[1] == 'u')
+        {
+            return CL_Color_Purple;
+        }
+    }
+    else if (color[0] == 'r')
+    {
+        if (color[2] == 'p')
+        {
+            return CL_Color_Reply2cmd;
+        }
+        else if (color[2] == 'd')
+        {
+            return CL_Color_Red;
+        }
+    }
+    else if (color[0] == 's')
+    {
+        if (color[1] == 'h')
+        {
+            return CL_Color_Showactivity;
+        }
+        else if (color[1] == 'e')
+        {
+            return CL_Color_Settings;
+        }
+    }
+    else if (color[0] == 'e')
+    {
+        return CL_Color_Error;
+    }
+    else if (color[0] == 'h')
+    {
+        return CL_Color_Highlight;
+    }
+    else if (color[0] == 'c')
+    {
+        return CL_Color_Command;
+    }
+    else if (color[0] == 't')
+    {
+        if (color[4] == ' ')
+        {
+            if (color[5] == '0')
+            {
+                return CL_Color_Team_0;
+            }
+            else if (color[5] == '1')
+            {
+                return CL_Color_Team_1;
+            }
+            else if (color[5] == '2')
+            {
+                return CL_Color_Team_2;
+            }
+        }
+        else if (color[4] == 'c')
+        {
+            return CL_Color_Teamcolor;
+        }
+    }
+    else if (color[0] == 'l')
+    {
+        if (color[2] == 'g')
+        {
+            if (color[5] == 'r')
+            {
+                return CL_Color_Lightred;
+            }
+            else if (color[5] == 'g')
+            {
+                return CL_Color_Lightgreen;
+            }
+        }
+        else if (color[2] == 'm')
+        {
+            return CL_Color_Lime;
+        }
+    }
+    else if (color[0] == 'b')
+    {
+        if (color[4] == 'g')
+        {
+            return CL_Color_Bluegrey;
+        }
+        else if (color[4] == 0x0)
+        {
+            return CL_Color_Blue;
+        }
+    }
+    else if (color[0] == 'o')
+    {
+        if (color[2] == 'c')
+        {
+            return CL_Color_Orchid;
+        }
+        else if (color[2] == 'a')
+        {
+            return CL_Color_Orange;
+        }
+    }
+    else if (color[0] == 'y')
+    {
+        return CL_Color_Yellow;
+    }
+    else if (color[0] == 'g')
+    {
+        if (color[1] == 'o')
+        {
+            return CL_Color_Gold;
+        }
+        else if (color[1] == 'r')
+        {
+            if (color[3] == 'e')
+            {
+                return CL_Color_Green;
+            }
+            else if (color[3] == 'y')
+            {
+                if (color[4] == 0x0)
+                {
+                    return CL_Color_Grey;
+                }
+                else if (color[4] == '2')
+                {
+                    return CL_Color_Grey2;
+                }
+            }
+        }
+    }
+
+    return view_as<CL_Colors>(0x00);
+}
+

--- a/addons/sourcemod/scripting/include/colorlib_map.inc
+++ b/addons/sourcemod/scripting/include/colorlib_map.inc
@@ -24,6 +24,13 @@ enum CL_Colors
     CL_Color_Team_1 = 0x09,
     CL_Color_Team_2 = 0x11,
     CL_Color_Teamcolor = 0x03,
+    CL_Color_Gray = 0x08,
+    CL_Color_Gray2 = 0x0D,
+    CL_Color_Bluegray = 0x0A,
+    CL_Color_Steelblue = 0x0D,
+    CL_Color_Pink = 0x0E,
+    CL_Color_Lightblue = 0x0A,
+    CL_Color_Olive = 0x05,
     CL_Color_Red = 0x07,
     CL_Color_Lightred = 0x0F,
     CL_Color_Darkred = 0x02,
@@ -72,6 +79,10 @@ CL_Colors _CL_ColorMap(char color[16])
         {
             return CL_Color_Player;
         }
+        else if (color[1] == 'i')
+        {
+            return CL_Color_Pink;
+        }
         else if (color[1] == 'u')
         {
             return CL_Color_Purple;
@@ -97,6 +108,10 @@ CL_Colors _CL_ColorMap(char color[16])
         else if (color[1] == 'e')
         {
             return CL_Color_Settings;
+        }
+        else if (color[1] == 't')
+        {
+            return CL_Color_Steelblue;
         }
     }
     else if (color[0] == 'e')
@@ -133,11 +148,72 @@ CL_Colors _CL_ColorMap(char color[16])
             return CL_Color_Teamcolor;
         }
     }
+    else if (color[0] == 'g')
+    {
+        if (color[1] == 'r')
+        {
+            if (color[2] == 'a')
+            {
+                if (color[4] == 0x0)
+                {
+                    return CL_Color_Gray;
+                }
+                else if (color[4] == '2')
+                {
+                    return CL_Color_Gray2;
+                }
+            }
+            else if (color[2] == 'e')
+            {
+                if (color[3] == 'e')
+                {
+                    return CL_Color_Green;
+                }
+                else if (color[3] == 'y')
+                {
+                    if (color[4] == 0x0)
+                    {
+                        return CL_Color_Grey;
+                    }
+                    else if (color[4] == '2')
+                    {
+                        return CL_Color_Grey2;
+                    }
+                }
+            }
+        }
+        else if (color[1] == 'o')
+        {
+            return CL_Color_Gold;
+        }
+    }
+    else if (color[0] == 'b')
+    {
+        if (color[4] == 'g')
+        {
+            if (color[6] == 'a')
+            {
+                return CL_Color_Bluegray;
+            }
+            else if (color[6] == 'e')
+            {
+                return CL_Color_Bluegrey;
+            }
+        }
+        else if (color[4] == 0x0)
+        {
+            return CL_Color_Blue;
+        }
+    }
     else if (color[0] == 'l')
     {
         if (color[2] == 'g')
         {
-            if (color[5] == 'r')
+            if (color[5] == 'b')
+            {
+                return CL_Color_Lightblue;
+            }
+            else if (color[5] == 'r')
             {
                 return CL_Color_Lightred;
             }
@@ -151,56 +227,27 @@ CL_Colors _CL_ColorMap(char color[16])
             return CL_Color_Lime;
         }
     }
-    else if (color[0] == 'b')
-    {
-        if (color[4] == 'g')
-        {
-            return CL_Color_Bluegrey;
-        }
-        else if (color[4] == 0x0)
-        {
-            return CL_Color_Blue;
-        }
-    }
     else if (color[0] == 'o')
     {
-        if (color[2] == 'c')
+        if (color[1] == 'l')
         {
-            return CL_Color_Orchid;
+            return CL_Color_Olive;
         }
-        else if (color[2] == 'a')
+        else if (color[1] == 'r')
         {
-            return CL_Color_Orange;
+            if (color[2] == 'c')
+            {
+                return CL_Color_Orchid;
+            }
+            else if (color[2] == 'a')
+            {
+                return CL_Color_Orange;
+            }
         }
     }
     else if (color[0] == 'y')
     {
         return CL_Color_Yellow;
-    }
-    else if (color[0] == 'g')
-    {
-        if (color[1] == 'o')
-        {
-            return CL_Color_Gold;
-        }
-        else if (color[1] == 'r')
-        {
-            if (color[3] == 'e')
-            {
-                return CL_Color_Green;
-            }
-            else if (color[3] == 'y')
-            {
-                if (color[4] == 0x0)
-                {
-                    return CL_Color_Grey;
-                }
-                else if (color[4] == '2')
-                {
-                    return CL_Color_Grey2;
-                }
-            }
-        }
     }
 
     return view_as<CL_Colors>(0x00);

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -459,10 +459,11 @@ public Action Say_Hook(int client, const char[] command, int argc)
 		else
 		{
 			char szChatRank[1024];
-			Format(szChatRank, 1024, "%s", g_pr_chat_coloredrank[client]);
+			Format(szChatRank, sizeof(szChatRank), "%s", g_pr_chat_coloredrank[client]);
+
 			char szChatRankColor[1024];
-			Format(szChatRankColor, 1024, "%s", g_pr_chat_coloredrank[client]);
-			CGetRankColor(szChatRankColor, 1024);
+			Format(szChatRankColor, sizeof(szChatRankColor), "%s", g_pr_chat_coloredrank[client]);
+			CGetRankColor(szChatRankColor, sizeof(szChatRankColor));
 
 			if (GetConVarBool(g_hPointSystem) && GetConVarBool(g_hColoredNames) && !g_bDbCustomTitleInUse[client])
 				Format(szName, sizeof(szName), "{%s}%s", szChatRankColor, szName);
@@ -493,12 +494,11 @@ public Action Say_Hook(int client, const char[] command, int argc)
 
 public void CGetRankColor(char[] sMsg, int iSize) // edit from CProcessVariables - colorvars
 {
-	if (!Init()) {
-		return;
-	}
-
-	char[] sOut = new char[iSize]; char[] sCode = new char[iSize]; char[] sColor = new char[iSize];
-	int iOutPos = 0; int iCodePos = -1;
+	char[] sOut = new char[iSize];
+	char[] sCode = new char[iSize];
+	char[] sColor = new char[iSize];
+	int iOutPos = 0;
+	int iCodePos = -1;
 	int iMsgLen = strlen(sMsg);
 	int dev = 0;
 
@@ -516,7 +516,9 @@ public void CGetRankColor(char[] sMsg, int iSize) // edit from CProcessVariables
 				String_ToLower(sCode, sCode, iSize);
 
 				if (CGetColor(sCode, sColor, iSize)) {
-					if(dev == 1) break;
+					if(dev == 1) {
+						break;
+					}
 					dev++;
 				} else {
 					Format(sOut, iSize, "%s{%s}", sOut, sCode);

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4648,3 +4648,63 @@ void PrintCSGOHUDText(int client, const char[] format, any ...)
 
 	EndMessage();
 }
+
+// Copied this stock from colorvariables with some modifications (new syntax, replaced stuff with g_hColor )
+bool CGetColor(const char[] sName, char[] sColor, int iColorSize)
+{
+	if (sName[0] == '\0')
+		return false;
+
+	if (sName[0] == '@') {
+		int iSpace;
+		char sData[64];
+		char m_sName[64];
+		strcopy(m_sName, sizeof(m_sName), sName[1]);
+
+		if ((iSpace = FindCharInString(m_sName, ' ')) != -1 && (iSpace + 1 < strlen(m_sName))) {
+			strcopy(m_sName, iSpace + 1, m_sName);
+			strcopy(sData, sizeof(sData), m_sName[iSpace + 1]);
+		}
+
+		if (sColor[0] != '\0') {
+			return true;
+		}
+
+	} else if (sName[0] == '#') {
+		if (strlen(sName) == 7) {
+			Format(sColor, iColorSize, "\x07%s", sName[1]);
+			return true;
+		}
+		if (strlen(sName) == 9) {
+			Format(sColor, iColorSize, "\x08%s", sName[1]);
+			return true;
+		}
+	} else if (StrContains(sName, "player ", false) == 0 && strlen(sName) > 7) {
+		int iClient = StringToInt(sName[7]);
+
+		if (iClient < 1 || iClient > MaxClients || !IsClientInGame(iClient)) {
+			strcopy(sColor, iColorSize, "\x01");
+			LogError("Invalid client index %d", iClient);
+			return false;
+		}
+
+		strcopy(sColor, iColorSize, "\x01");
+		switch (GetClientTeam(iClient)) {
+			case 1: {
+				Format(sColor, iColorSize, "team 0");
+			}
+			case 2: {
+				Format(sColor, iColorSize, "team 1");
+			}
+			case 3: {
+				Format(sColor, iColorSize, "team 2");
+			}
+		}
+		return true;
+	} else {
+		Format(sColor, iColorSize, sName);
+		return true;
+	}
+
+	return false;
+}

--- a/tools/colors.yaml
+++ b/tools/colors.yaml
@@ -12,6 +12,13 @@ colors:
   team 1:       0x09
   team 2:       0x11
   teamcolor:    0x03
+  gray:         grey
+  gray2:        grey2
+  bluegray:     bluegrey
+  steelblue:    grey2
+  pink:         orchid
+  lightblue:    bluegrey
+  olive:        lightgreen
 ref_colors:
   red:          0x07
   lightred:     0x0F
@@ -29,3 +36,4 @@ ref_colors:
   lime:         0x06
   grey:         0x08
   grey2:        0x0D
+

--- a/tools/colors.yaml
+++ b/tools/colors.yaml
@@ -1,0 +1,31 @@
+colors:
+  default:      engine 1
+  prefix:       green
+  reply2cmd:    engine 1
+  showactivity: engine 1
+  error:        red
+  highlight:    orange
+  player:       yellow
+  settings:     darkred
+  command:      darkred
+  team 0:       0x08
+  team 1:       0x09
+  team 2:       0x11
+  teamcolor:    0x03
+ref_colors:
+  red:          0x07
+  lightred:     0x0F
+  darkred:      0x02
+  bluegrey:     0x0A
+  blue:         0x0B
+  darkblue:     0x0C
+  purple:       0x03
+  orchid:       0x0E
+  orange:       0x10
+  yellow:       0x09
+  gold:         0x10
+  lightgreen:   0x05
+  green:        0x04
+  lime:         0x06
+  grey:         0x08
+  grey2:        0x0D


### PR DESCRIPTION
ColorLib on [Github](https://github.com/c0rp3n/colorlib-sm) and on [AlliedModders](https://forums.alliedmods.net/showthread.php?t=320842)

Reason for ColorLib:

> The reason for this is that Colors and More Colors both make heavy use of many ReplaceString operations each one looping through the buffer being formatted, whereas this could be avoided by writing a single pass formatter as used here and was done for ColorVariables.
And to why replace ColorVariables? it also adds extra overhead with forwards and allowing for more "dynamic" colors, which isnt always needed.

[Source](https://forums.alliedmods.net/showthread.php?t=320842)