### PR TITLE
Restore Previous Records

### DIFF
--- a/addons/sourcemod/scripting/surftimer/db/queries.sp
+++ b/addons/sourcemod/scripting/surftimer/db/queries.sp
@@ -84,6 +84,7 @@ char sql_selectPlayerProCount[] = "SELECT style, count(1) FROM ck_playertimes WH
 char sql_selectPlayerRankProTime[] = "SELECT COUNT(*) FROM ck_playertimes WHERE runtimepro <= (SELECT runtimepro FROM ck_playertimes WHERE steamid = '%s' AND mapname = '%s' AND style = 0 AND runtimepro > -1.0) AND mapname = '%s' AND style = 0 AND runtimepro > -1.0;";
 char sql_selectAllMapTimesinMap[] = "SELECT runtimepro from ck_playertimes WHERE mapname = '%s';";
 char sql_selectAVGruntimepro[] = "SELECT AVG(runtimepro) FROM ck_playertimes WHERE mapname = '%s';";
+char sql_selectMapRecordDeletion[] = "SELECT MIN(%s), steamid, style FROM %s WHERE mapname='%s' AND style='%i' AND %s > -1.0 %s";
 
 // ck_spawnlocations
 char sql_createSpawnLocations[] = "CREATE TABLE IF NOT EXISTS ck_spawnlocations (mapname VARCHAR(54) NOT NULL, pos_x FLOAT NOT NULL, pos_y FLOAT NOT NULL, pos_z FLOAT NOT NULL, ang_x FLOAT NOT NULL, ang_y FLOAT NOT NULL, ang_z FLOAT NOT NULL,  `vel_x` float NOT NULL DEFAULT '0', `vel_y` float NOT NULL DEFAULT '0', `vel_z` float NOT NULL DEFAULT '0', zonegroup INT(12) DEFAULT 0, stage INT(12) DEFAULT 0, teleside INT(11) DEFAULT 0, PRIMARY KEY(mapname, zonegroup, stage, teleside)) DEFAULT CHARSET=utf8mb4;";

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -8696,6 +8696,7 @@ public void db_selectMapCurrentWR(Handle owner, Handle hndl, const char[] error,
 	if (hndl == null)
 	{
 		LogError("[SurfTimer] SQL Error (db_selectMapCurrentWR): %s", error);
+		CloseHandle(pack);
 		return;
 	}
 
@@ -8706,7 +8707,6 @@ public void db_selectMapCurrentWR(Handle owner, Handle hndl, const char[] error,
 		ReadPackString(pack, szSteamId, sizeof(szSteamId));
 		ReadPackString(pack, szStyleType, sizeof(szStyleType));
 		int iLevel = ReadPackCell(pack);
-		CloseHandle(pack);
 
 		char sSteamId[32];
 		SQL_FetchString(hndl, 1, sSteamId, sizeof(sSteamId));
@@ -8763,6 +8763,8 @@ public void db_selectMapCurrentWR(Handle owner, Handle hndl, const char[] error,
 			}
 		}
 	}
+	
+	CloseHandle(pack);
 }
 
 // sm_pr command

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -299,27 +299,43 @@ public int callback_Confirm(Menu menu, MenuAction action, int client, int key)
 			char steamID[32];
 			menu.GetItem(key, steamID, 32);
 			
-			char szQuery[512];
+			char szQuery[512], szQuerySelect[512];
+
+			Handle pack = CreateDataPack();
+			WritePackString(pack, steamID);
 			
 			switch(g_SelectedEditOption[client])
 			{
 				case 0:
 				{
+					WritePackString(pack, "");
+					WritePackCell(pack, 0);
+
 					FormatEx(szQuery, 512, sql_MainDeleteQeury, "ck_playertimes", g_EditingMap[client], g_SelectedStyle[client], steamID, "");
+					FormatEx(szQuerySelect, 512, sql_selectMapRecordDeletion, "runtimepro", "ck_playertimes", g_EditingMap[client], g_SelectedStyle[client], "runtimepro", "");
 				}
 				case 1:
 				{
+					WritePackString(pack, "stage");
+					WritePackCell(pack, g_SelectedType[client]);
+
 					char stageQuery[32];
 					FormatEx(stageQuery, 32, "AND stage='%i'", g_SelectedType[client]);
 					FormatEx(szQuery, 512, sql_MainDeleteQeury, "ck_wrcps", g_EditingMap[client], g_SelectedStyle[client], steamID, stageQuery);
+					FormatEx(szQuerySelect, 512, sql_selectMapRecordDeletion, "runtimepro", "ck_wrcps", g_EditingMap[client], g_SelectedStyle[client], "runtimepro", stageQuery);
 				}
 				case 2:
 				{
+					WritePackString(pack, "bonus");
+					WritePackCell(pack, g_SelectedType[client]);
+
 					char zoneQuery[32];
 					FormatEx(zoneQuery, 32, "AND zonegroup='%i'", g_SelectedType[client]);
 					FormatEx(szQuery, 512, sql_MainDeleteQeury, "ck_bonus", g_EditingMap[client], g_SelectedStyle[client], steamID, zoneQuery);
+					FormatEx(szQuerySelect, 512, sql_selectMapRecordDeletion, "runtime", "ck_bonus", g_EditingMap[client], g_SelectedStyle[client], "runtime", zoneQuery);
 				}
 			}
+			SQL_TQuery(g_hDb, db_selectMapCurrentWR, szQuerySelect, pack, DBPrio_High);
 			SQL_TQuery(g_hDb, SQL_CheckCallback, szQuery, DBPrio_Low);
 			
 			// Looking for online player to refresh his record after deleting it.
@@ -8673,6 +8689,80 @@ public int ChooseMapMenuHandler(Menu menu, MenuAction action, int param1, int pa
 	}
 	else if (action == MenuAction_End)
 		delete menu;
+}
+
+public void db_selectMapCurrentWR(Handle owner, Handle hndl, const char[] error, any pack)
+{
+	if (hndl == null)
+	{
+		LogError("[SurfTimer] SQL Error (db_selectMapCurrentWR): %s", error);
+		return;
+	}
+
+	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
+	{
+		ResetPack(pack);
+		char szSteamId[32], szStyleType[5];
+		ReadPackString(pack, szSteamId, sizeof(szSteamId));
+		ReadPackString(pack, szStyleType, sizeof(szStyleType));
+		int iLevel = ReadPackCell(pack);
+		CloseHandle(pack);
+
+		char sSteamId[32];
+		SQL_FetchString(hndl, 1, sSteamId, sizeof(sSteamId));
+		int iStyle = SQL_FetchInt(hndl, 2);
+
+		if (StrEqual(szSteamId, sSteamId))
+		{
+			// Check if backup exists
+			char sPathBack[256];
+			if (StrEqual(szStyleType, "bonus"))
+				if (iStyle == 0)
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s_bonus_%i.rec.bak", CK_REPLAY_PATH, g_szMapName, iLevel);
+				else
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s_bonus_%i_style_%i.rec.bak", CK_REPLAY_PATH, g_szMapName, iLevel, iStyle);
+			else if (StrEqual(szStyleType, "stage"))
+				if (iStyle == 0)
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s_stage_%i.rec.bak", CK_REPLAY_PATH, g_szMapName, iLevel);
+				else
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s_stage_%i_style_%i.rec.bak", CK_REPLAY_PATH, g_szMapName, iLevel, iStyle);
+			else if (StrEqual(szStyleType, ""))
+				if (iStyle == 0)
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s.rec.bak", CK_REPLAY_PATH, g_szMapName);
+				else
+					BuildPath(Path_SM, sPathBack, sizeof(sPathBack), "%s%s_style_%i.rec.bak", CK_REPLAY_PATH, g_szMapName, iStyle);
+			
+			if (FileExists(sPathBack))
+			{
+				char sPath[256];
+				if (StrEqual(szStyleType, "bonus"))
+					if (iStyle == 0)
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s_bonus_%i.rec", CK_REPLAY_PATH, g_szMapName, iLevel);
+					else
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s_bonus_%i_style_%i.rec", CK_REPLAY_PATH, g_szMapName, iLevel, iStyle);
+				else if (StrEqual(szStyleType, "stage"))
+					if (iStyle == 0)
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s_stage_%i.rec", CK_REPLAY_PATH, g_szMapName, iLevel);
+					else
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s_stage_%i_style_%i.rec", CK_REPLAY_PATH, g_szMapName, iLevel, iStyle);
+				else if (StrEqual(szStyleType, ""))
+					if (iStyle == 0)
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s.rec", CK_REPLAY_PATH, g_szMapName);
+					else
+						BuildPath(Path_SM, sPath, sizeof(sPath), "%s%s_style_%i.rec", CK_REPLAY_PATH, g_szMapName, iStyle);
+				
+				if (FileExists(sPath))
+				{
+					DeleteFile(sPath);
+					RenameFile(sPathBack, sPath);
+					setReplayTime(0, 0, 0);
+
+					CreateTimer(5.0, FixBot_Off, INVALID_HANDLE, TIMER_FLAG_NO_MAPCHANGE);
+					CreateTimer(10.0, FixBot_On, INVALID_HANDLE, TIMER_FLAG_NO_MAPCHANGE);
+				}
+			}
+		}
+	}
 }
 
 // sm_pr command


### PR DESCRIPTION
It seems like this fork of the timer has never had the ability to delete the previous bot file? That's very odd so I've added this as well as when you delete a record, instead of just deleting the .rec and being done with it, it'll restore the previously stored record. 