### PR TITLE
fix #91

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -124,7 +124,7 @@
 #define MAX_LOCS 1024
 
 //CSGO HUD Hint Fix
-#define MAX_HINT_SIZE 225
+#define MAX_HINT_SIZE 227
 
 /*====================================
 =            Enumerations            =

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4901,10 +4901,10 @@ void PrintCSGOHUDText(int client, const char[] format, any ...)
 {
 	char buff[MAX_HINT_SIZE];
 	VFormat(buff, sizeof(buff), format, 3);
-	Format(buff, sizeof(buff), "</font>%s ", buff);
+	Format(buff, sizeof(buff), "</font>%s", buff);
 
 	for(int i = strlen(buff); i < sizeof(buff) - 1; i++)
-		buff[i] = '\n';
+		buff[i] = ' ';
 	
 	buff[sizeof(buff) - 1] = '\0';
 


### PR DESCRIPTION
In my pr #74 I said that I was using the same function in my timer but actually it was slightly different which I didn't think mattered. I was using bigger array in my function and I was filling the array with ' ' characters instead of '\n'. After I modified it to be exactly the same as in the current dev branch I confirmed the same problem but the extra character in my hud wasn't "f" but "t".

So why did that "f" or "t" appear in hud after my latest commit? Because we removed the last '\n' from the array and replaced it with '\0' we also need to grow the array by one because without that it doesn't completely fill the buffer of hinttext and one extra character from SFUI_ContractKillStart comes to hud.

I'm using english as my csgo language and in english SFUI_ContractKillStart is "<font color='#45b512'>$%s1</font> to eliminate the <font color='#e58816'>High Value Target</font>." %s1 is the part of the text we are controlling and "t" is the next character in that translation.

So to fix #91 I'm increasing MAX_HINT_SIZE by 2 to fix it for users who are using the default translation and users who have removed the "$" from their translation file.